### PR TITLE
percentageState added to ENDPOINT_LOW_POWER validation

### DIFF
--- a/validation_schemas/alexa_smart_home_message_schema.json
+++ b/validation_schemas/alexa_smart_home_message_schema.json
@@ -2055,6 +2055,9 @@
                     },
                     "message": {
                         "$ref": "#/definitions/common.properties/message"
+                    },
+                    "percentageState": {
+                        "type": "number"
                     }
                 }
             },


### PR DESCRIPTION
ENDPOINT_LOW_POWER example response has "percentageState" value, but it is not covered in validation schema. Therefore percentageState added to the validation.