### PR TITLE
Fixing default value for EndpointHealth context property

### DIFF
--- a/sample_backend/lambda/lambda_api/python/alexa/skills/smarthome/alexa_response.py
+++ b/sample_backend/lambda/lambda_api/python/alexa/skills/smarthome/alexa_response.py
@@ -54,7 +54,7 @@ class AlexaResponse:
         p = {}
         p['namespace'] = kwargs.get('namespace', 'Alexa.EndpointHealth')
         p['name'] = kwargs.get('name', 'connectivity')
-        p['value'] = kwargs.get('value', {'value': 'OK'})
+        p['value'] = kwargs.get('value', 'OK')
         p['timeOfSample'] = get_utc_timestamp()
         p['uncertaintyInMilliseconds'] = kwargs.get('uncertainty_in_milliseconds', 0)
         return p

--- a/sample_backend/lambda/lambda_api/python/endpoint_cloud/api_handler_directive.py
+++ b/sample_backend/lambda/lambda_api/python/endpoint_cloud/api_handler_directive.py
@@ -209,6 +209,8 @@ class ApiHandlerDirective:
                         name='powerState',
                         value=power_state_value)
 
+                    alexa_power_controller_response.add_property()
+
                     response = alexa_power_controller_response.get()
 
                 except ClientError as e:


### PR DESCRIPTION
Updated the default connectivity value to be correct against the schema and included it as a default for the Alexa.PowerController directive response.