### PR TITLE
Add Smart Home Automated Capability Evaluations' Test Plans.

### DIFF
--- a/capability_evaluations/test_plans/BrightnessController
+++ b/capability_evaluations/test_plans/BrightnessController
@@ -1,0 +1,1332 @@
+{
+    "name": "BrightnessController",
+    "testCases": [
+        {
+            "name": "DevRe_1.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_1.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOff"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 25
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_1.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 25
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 25
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_3.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "SetBrightness"
+                },
+                "payload": {
+                    "brightness": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 25
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_4.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 10
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 100
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_5.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 25
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_5.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 25
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 25
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_6.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "DevRe_7.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 0
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 0
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 0
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "DevRe_8.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 75
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "DevRe_9.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "SetBrightness"
+                },
+                "payload": {
+                    "brightness": 0
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "DevRe_9.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 0
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 0
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 100
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_10.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 25
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 25
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "DevRe_11.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOff"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "Bulb_1.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 120.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 120.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 120.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 120.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 100
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 100
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 75
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 120.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 120.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 75
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 120.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 120.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "SetBrightness"
+                },
+                "payload": {
+                    "brightness": 50
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ColorController
+++ b/capability_evaluations/test_plans/ColorController
@@ -1,0 +1,925 @@
+{
+    "name": "ColorController",
+    "testCases": [
+        {
+            "name": "Clr_1.0.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.0.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.0.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 240.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 240.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.0.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 277.0,
+                        "saturation": 0.8619,
+                        "brightness": 0.9373
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 277.0,
+                        "saturation": 0.8619,
+                        "brightness": 0.9373
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.0.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 60.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 60.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.0.5",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 39.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 39.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.1.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.1.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 120.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Clr_1.1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorController",
+                    "name": "SetColor"
+                },
+                "payload": {
+                    "color": {
+                        "hue": 240.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 240.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 0.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 0.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 0.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 0.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": -25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 25
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 0.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 0.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "AdjustBrightness"
+                },
+                "payload": {
+                    "brightnessDelta": 25
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 75
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "Bulb_2.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorController",
+                        "name": "color",
+                        "value": {
+                            "hue": 0.0,
+                            "saturation": 1.0,
+                            "brightness": 1.0
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorController",
+                            "name": "SetColor"
+                        },
+                        "payload": {
+                            "color": {
+                                "hue": 0.0,
+                                "saturation": 1.0,
+                                "brightness": 1.0
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "SetBrightness"
+                },
+                "payload": {
+                    "brightness": 50
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "value": {
+                        "hue": 0.0,
+                        "saturation": 1.0,
+                        "brightness": 1.0
+                    }
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.ColorController",
+                    "name": "color",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ColorTemperatureController
+++ b/capability_evaluations/test_plans/ColorTemperatureController
@@ -1,0 +1,1494 @@
+{
+    "name": "ColorTemperatureController",
+    "testCases": [
+        {
+            "name": "ClrRlt_1.0.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 2200,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 2200
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.0.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 4000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 4000
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.0.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 7000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 7000
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.1.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 2200,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 2200
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 7000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 7000
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.1.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 4000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 4000
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 7000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 7000
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 2200,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 2200
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.2.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 2200,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 2200
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.2.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 4000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 4000
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.2.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 7000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 7000
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "IncreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "GREATER_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.3.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 7000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 7000
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.3.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 4000,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 4000
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "ClrRlt_1.3.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ColorTemperatureController",
+                        "name": "colorTemperatureInKelvin",
+                        "value": 2200,
+                        "compare": "EQUAL_TO"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ColorTemperatureController",
+                            "name": "SetColorTemperature"
+                        },
+                        "payload": {
+                            "colorTemperatureInKelvin": 2200
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "DecreaseColorTemperature"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "LESS_THAN"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.0.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 2200
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.0.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 2700
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2700,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.0.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 4000
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.0.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 5500
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 5500,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.0.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 7000
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 7000
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "EQUAL_TO"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.2.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 2200
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 2200,
+                    "compare": "EQUAL_TO"
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.2.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 4000
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 4000,
+                    "compare": "EQUAL_TO"
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        },
+        {
+            "name": "TunWht_1.2.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.BrightnessController",
+                        "name": "brightness",
+                        "value": 50
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.BrightnessController",
+                            "name": "SetBrightness"
+                        },
+                        "payload": {
+                            "brightness": 50
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "SetColorTemperature"
+                },
+                "payload": {
+                    "colorTemperatureInKelvin": 7000
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                },
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "value": 7000,
+                    "compare": "EQUAL_TO"
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "value": 50
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ColorTemperatureController",
+                    "name": "colorTemperatureInKelvin",
+                    "percentThreshold": 5
+                },
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                },
+                {
+                    "namespace": "Alexa.BrightnessController",
+                    "name": "brightness",
+                    "percentThreshold": 5
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/PowerController
+++ b/capability_evaluations/test_plans/PowerController
@@ -1,0 +1,85 @@
+{
+    "name": "PowerController",
+    "testCases": [
+        {
+            "name": "DevRe_1.0",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "OFF"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOff"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOn"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "ON"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "DevRe_1.1",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": "ON"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.PowerController",
+                            "name": "TurnOn"
+                        },
+                        "payload": null
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.PowerController",
+                    "name": "TurnOff"
+                },
+                "payload": null
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "value": "OFF"
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.PowerController",
+                    "name": "powerState",
+                    "percentThreshold": 0
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ThermostatAuto
+++ b/capability_evaluations/test_plans/ThermostatAuto
@@ -1,0 +1,167 @@
+{
+  "name": "ThermostatAuto",
+  "testCases": [
+    {
+      "name": "Auto_1.0",
+      "initialSetups": [
+        {
+          "capabilityState": {
+            "namespace": "Alexa.ThermostatController",
+            "name": "thermostatMode",
+            "value": "COOL"
+          },
+          "directive": {
+            "header": {
+              "namespace": "Alexa.ThermostatController",
+              "name": "SetThermostatMode"
+            },
+            "payload": {
+              "thermostatMode": {
+                "value": "COOL"
+              }
+            }
+          }
+        }
+      ],
+      "directive": {
+        "header": {
+          "namespace": "Alexa.ThermostatController",
+          "name": "SetThermostatMode"
+        },
+        "payload": {
+          "thermostatMode": {
+            "value": "AUTO"
+          }
+        }
+      },
+      "expectedCapabilityStates": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "value": "AUTO"
+        }
+      ],
+      "capabilityTolerances": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "percentThreshold": 2
+        }
+      ]
+    },
+    {
+      "name": "Auto_1.1",
+      "initialSetups": [
+        {
+          "capabilityState": {
+            "namespace": "Alexa.ThermostatController",
+            "name": "thermostatMode",
+            "value": "HEAT"
+          },
+          "directive": {
+            "header": {
+              "namespace": "Alexa.ThermostatController",
+              "name": "SetThermostatMode"
+            },
+            "payload": {
+              "thermostatMode": {
+                "value": "HEAT"
+              }
+            }
+          }
+        }
+      ],
+      "directive": {
+        "header": {
+          "namespace": "Alexa.ThermostatController",
+          "name": "SetThermostatMode"
+        },
+        "payload": {
+          "thermostatMode": {
+            "value": "AUTO"
+          }
+        }
+      },
+      "expectedCapabilityStates": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "value": "AUTO"
+        }
+      ],
+      "capabilityTolerances": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "percentThreshold": 2
+        }
+      ]
+    },
+    {
+      "name": "Auto_1.2",
+      "initialSetups": [
+        {
+          "capabilityState": {
+            "namespace": "Alexa.ThermostatController",
+            "name": "thermostatMode",
+            "value": "COOL"
+          },
+          "directive": {
+            "header": {
+              "namespace": "Alexa.ThermostatController",
+              "name": "SetThermostatMode"
+            },
+            "payload": {
+              "thermostatMode": {
+                "value": "COOL"
+              }
+            }
+          }
+        },
+        {
+          "capabilityState": {
+            "namespace": "Alexa.ThermostatController",
+            "name": "thermostatMode",
+            "value": "HEAT"
+          },
+          "directive": {
+            "header": {
+              "namespace": "Alexa.ThermostatController",
+              "name": "SetThermostatMode"
+            },
+            "payload": {
+              "thermostatMode": {
+                "value": "HEAT"
+              }
+            }
+          }
+        }
+      ],
+      "directive": {
+        "header": {
+          "namespace": "Alexa.ThermostatController",
+          "name": "SetThermostatMode"
+        },
+        "payload": {
+          "thermostatMode": {
+            "value": "AUTO"
+          }
+        }
+      },
+      "expectedCapabilityStates": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "value": "AUTO"
+        }
+      ],
+      "capabilityTolerances": [
+        {
+          "namespace": "Alexa.ThermostatController",
+          "name": "thermostatMode",
+          "percentThreshold": 2
+        }
+      ]
+    }
+  ]
+}

--- a/capability_evaluations/test_plans/ThermostatCool_CELSIUS
+++ b/capability_evaluations/test_plans/ThermostatCool_CELSIUS
@@ -1,0 +1,242 @@
+{
+    "name": "ThermostatCool_CELSIUS",
+    "testCases": [
+        {
+            "name": "CelCool_1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 32.0,
+                            "scale": "CELSIUS"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 32.0,
+                                "scale": "CELSIUS"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "SetTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpoint": {
+                        "value": 17,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 17,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "CelCool_1.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 36,
+                            "scale": "CELSIUS"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 36,
+                                "scale": "CELSIUS"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": -6.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 30,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "CelCool_1.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 24,
+                            "scale": "CELSIUS"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 24,
+                                "scale": "CELSIUS"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": 6.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 30,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ThermostatCool_FAHRENHEIT
+++ b/capability_evaluations/test_plans/ThermostatCool_FAHRENHEIT
@@ -1,0 +1,242 @@
+{
+    "name": "ThermostatCool_FAHRENHEIT",
+    "testCases": [
+        {
+            "name": "FahCool_1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 90,
+                            "scale": "FAHRENHEIT"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 90,
+                                "scale": "FAHRENHEIT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "SetTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpoint": {
+                        "value": 64,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 64,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "FahCool_1.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 90,
+                            "scale": "FAHRENHEIT"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 90,
+                                "scale": "FAHRENHEIT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": -6.0,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 84,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "FahCool_1.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "COOL"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "COOL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 74,
+                            "scale": "FAHRENHEIT"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 74,
+                                "scale": "FAHRENHEIT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": 6.0,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 80,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ThermostatHeat_CELSIUS
+++ b/capability_evaluations/test_plans/ThermostatHeat_CELSIUS
@@ -1,0 +1,220 @@
+{
+    "name": "ThermostatHeat_CELSIUS",
+    "testCases": [
+        {
+            "name": "CelHeat_1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "SetTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpoint": {
+                        "value": 17,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 17.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "CelHeat_1.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 10.0,
+                            "scale": "CELSIUS"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 10.0,
+                                "scale": "CELSIUS"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": 6.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 16.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "CelHeat_1.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 26.0,
+                            "scale": "CELSIUS"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 26.0,
+                                "scale": "CELSIUS"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": -6.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 20.0,
+                        "scale": "CELSIUS"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        }
+    ]
+}

--- a/capability_evaluations/test_plans/ThermostatHeat_FAHRENHEIT
+++ b/capability_evaluations/test_plans/ThermostatHeat_FAHRENHEIT
@@ -1,0 +1,220 @@
+{
+    "name": "ThermostatHeat_FAHRENHEIT",
+    "testCases": [
+        {
+            "name": "FahHeat_1.2",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "SetTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpoint": {
+                        "value": 64,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 64,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "FahHeat_1.3",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 54,
+                            "scale": "FAHRENHEIT"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 54,
+                                "scale": "FAHRENHEIT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": 6.0,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 60,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        },
+        {
+            "name": "FahHeat_1.4",
+            "initialSetups": [
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "thermostatMode",
+                        "value": "HEAT"
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetThermostatMode"
+                        },
+                        "payload": {
+                            "thermostatMode": {
+                                "value": "HEAT"
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilityState": {
+                        "namespace": "Alexa.ThermostatController",
+                        "name": "targetSetpoint",
+                        "value": {
+                            "value": 60,
+                            "scale": "FAHRENHEIT"
+                        }
+                    },
+                    "directive": {
+                        "header": {
+                            "namespace": "Alexa.ThermostatController",
+                            "name": "SetTargetTemperature"
+                        },
+                        "payload": {
+                            "targetSetpoint": {
+                                "value": 60,
+                                "scale": "FAHRENHEIT"
+                            }
+                        }
+                    }
+                }
+            ],
+            "directive": {
+                "header": {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "AdjustTargetTemperature"
+                },
+                "payload": {
+                    "targetSetpointDelta": {
+                        "value": -6.0,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            },
+            "expectedCapabilityStates": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "value": {
+                        "value": 54,
+                        "scale": "FAHRENHEIT"
+                    }
+                }
+            ],
+            "capabilityTolerances": [
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "targetSetpoint",
+                    "percentThreshold": 2
+                },
+                {
+                    "namespace": "Alexa.ThermostatController",
+                    "name": "thermostatMode",
+                    "percentThreshold": 0
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available: Smart Home Automated Capability Evaluations tool is being exposed to 3Ps, hence the Test plans used by the tool needs to be in the Public repo for 3Ps to know the contents of the Test Plans.

*Description of changes: Added Smart Home Automated Capability Evaluations' Test Plans.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
