### PR TITLE
Update alexa_smart_home_message_schema.json

### DIFF
--- a/validation_schemas/alexa_smart_home_message_schema.json
+++ b/validation_schemas/alexa_smart_home_message_schema.json
@@ -12434,6 +12434,7 @@
                                                         "SCENE_TRIGGER",
                                                         "SCREEN",
                                                         "SECURITY_PANEL",
+                                                        "SECURITY_SYSTEM",
                                                         "SMARTLOCK",
                                                         "SMARTPLUG",
                                                         "SPEAKER",


### PR DESCRIPTION
The value SECURITY_SYSTEM is not present in displayCategories, but in the documentation it is.  

https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-discovery.html#display-categories

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
