### PR TITLE
Adding authentication configs to auto space capabilities- local, Mode…

### DIFF
--- a/validation_schemas/alexa_smart_home_message_schema.json
+++ b/validation_schemas/alexa_smart_home_message_schema.json
@@ -3412,6 +3412,40 @@
                                             }
                                         },
                                         "nullable": true
+                                    },
+                                    "directiveConfigurations": {
+                                        "type": "array",
+                                        "nullable": true,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directives": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "requestedAuthenticationConfidenceLevel": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "integer",
+                                                            "format": "int32"
+                                                        },
+                                                        "customPolicy": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "policyName": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
@@ -4480,6 +4514,40 @@
                                             }
                                         },
                                         "nullable": true
+                                    },
+                                    "directiveConfigurations": {
+                                        "type": "array",
+                                        "nullable": true,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directives": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "requestedAuthenticationConfidenceLevel": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "integer",
+                                                            "format": "int32"
+                                                        },
+                                                        "customPolicy": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "policyName": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
@@ -6319,6 +6387,40 @@
                                             }
                                         },
                                         "nullable": true
+                                    },
+                                    "directiveConfigurations": {
+                                        "type": "array",
+                                        "nullable": true,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directives": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "requestedAuthenticationConfidenceLevel": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "integer",
+                                                            "format": "int32"
+                                                        },
+                                                        "customPolicy": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "policyName": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
@@ -6733,6 +6835,40 @@
                                             }
                                         },
                                         "nullable": true
+                                    },
+                                    "directiveConfigurations": {
+                                        "type": "array",
+                                        "nullable": true,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directives": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "requestedAuthenticationConfidenceLevel": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "integer",
+                                                            "format": "int32"
+                                                        },
+                                                        "customPolicy": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "policyName": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
@@ -7308,6 +7444,40 @@
                                             }
                                         },
                                         "nullable": true
+                                    },
+                                    "directiveConfigurations": {
+                                        "type": "array",
+                                        "nullable": true,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directives": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "requestedAuthenticationConfidenceLevel": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "integer",
+                                                            "format": "int32"
+                                                        },
+                                                        "customPolicy": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "policyName": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "nullable": true
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },


### PR DESCRIPTION
… , Power, Range & Toggle

*Issue #, if available:* https://t.corp.amazon.com/P68996455

*Description of changes:*  Adding authentication configurations to smart Home capabilities used in auto space like Lock Mode Power Range and Toggle controllers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
